### PR TITLE
Initial modifications to allow one results file per container/node.

### DIFF
--- a/bin/mocktillery
+++ b/bin/mocktillery
@@ -55,17 +55,19 @@ program
 
 program
     .command("evaluate")
-    .option("-t, --testFile <file>", "mocktillery test output file")
+    .option("-t, --testFile [file]", "mocktillery test output file")
     .option("-d, --debug", "Debug flag")
     .action((cmdObj) => {
 
         if (!cmdObj.testFile)
             throw new Error("Must supply mocktillery test output file");
-        
+
+        let resultsFile = cmdObj.testFile.replace"(".json", ".result")
+
         if (cmdObj.debug)
             debug = true;
         
-        Mocktillery.evaluateTest(cmdObj.testFile);
+        Mocktillery.evaluateTest(cmdObj.testFile, resultsFile);
 
     });
     

--- a/lib/mocktillery.ts
+++ b/lib/mocktillery.ts
@@ -19,7 +19,7 @@ export class Mocktillery {
 
     }
 
-    public static evaluateTest(testFile: string): void {
+    public static evaluateTest(testFile: string, resultsFile: string): void {
 
         let cwd: string = process.cwd();
         let filePath: string = path.join(cwd, testFile);
@@ -39,10 +39,10 @@ export class Mocktillery {
         else
             results = TestResult.Fail;
 
-        this.saveEvaluation(results);
+        this.saveEvaluation(results, resultsFile);
     }
 
-    public static saveEvaluation(testResult: TestResult | undefined): void {
+    public static saveEvaluation(testResult: TestResult | undefined, resultsFile: string): void {
         /**
          * Ignore saving results if undefined
          */
@@ -50,7 +50,7 @@ export class Mocktillery {
             return;
 
         let cwd: string = process.cwd();
-        let outputFile: string = path.join(cwd, "latest.result");
+        let outputFile: string = path.join(cwd, resultsFile);
         try {
             fs.writeFileSync(outputFile, testResult);
         }catch(e) {
@@ -73,7 +73,7 @@ export class Mocktillery {
 
     /**
      * Public method that compiles all of the individual test cases and load test configuration,
-     * into one file "config.yml" which artillery uses to load up and run it's tests
+     * into one file "config.yml" which artillery uses to load up and run its tests
      */
     public compile(): void {
 


### PR DESCRIPTION
Chose to assume that the test output file name supplied will always have a '.json' suffix, so I just built off that.
Not completely happy with the passing through of the filename, be cleaner to have it in the object, but with status methods my hands were a bit tied.  Other changes are afoot so will get this in for now if I can.